### PR TITLE
ci: update action name after transfer

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -97,7 +97,7 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Setup TeX Live
-      uses: muzimuzhi/setup-texlive-action@v3
+      uses: TeX-Live/setup-texlive-action@v3
       with:
         package-file: .github/tl_packages
         update-all-packages: ${{ inputs.update-texlive-packages || true }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
     ## >>> setup begin
 
     - name: Setup TeX Live
-      uses: muzimuzhi/setup-texlive-action@v3
+      uses: TeX-Live/setup-texlive-action@v3
       with:
         package-file: .github/tl_packages
         update-all-packages: true


### PR DESCRIPTION
https://github.com/muzimuzhi/setup-texlive-action has been transferred to https://github.com/TeX-Live/setup-texlive-action.

My fork of `TeX-Live/setup-texlive-action` now lives in `muzimuzhi/setup-texlive-action-fork`, to let the auto-redirection for the old repo name working.