### PR TITLE
chore(lint): check format for justfiles

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -62,7 +62,7 @@ jobs:
 
     - name: Run pre-commit checks
       run: |
-        mise run pre-commit
+        mise run lint:pre-commit
       env:
         PRE_COMMIT_COLOR: always
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ ci:
 
       for more information, see https://pre-commit.ci
   autoupdate_commit_msg: 'chore(pre-commit): autoupdate'
-  skip: [check-spelling, lint-expl3, lint-python]
+  skip: [check-spelling, check-format-justfile, lint-expl3, lint-python]
 
 # path separator is normalized to "/", so no need to use "[\\/]" in python
 # regex, see
@@ -43,6 +43,13 @@ repos:
   - id: actionlint
 - repo: local
   hooks:
+  - id: check-format-justfile
+    alias: justfile
+    name: Check format for justfiles
+    language: unsupported
+    entry: mise run fmt:justfile --check
+    files: ^justfile$
+    pass_filenames: false
   # typos bumps version frequently, so use system installation instead of the
   # official pre-commit hook
   # https://github.com/crate-ci/typos/blob/master/docs/pre-commit.md

--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@
 # settings
 # https://github.com/casey/just?tab=readme-ov-file#settings
 
-set ignore-comments := true
+set ignore-comments
 set unstable
 
 ## variables
@@ -25,7 +25,7 @@ L3BUILD_SAVE_OPTIONS := env('L3BUILD_SAVE_OPTIONS', '-q')
 
 # List all recipes
 default:
-    just --justfile {{justfile()}} --list --unsorted
+    just --justfile {{ justfile() }} --list --unsorted
 
 [group('*meta')]
 test: zutil

--- a/mise.toml
+++ b/mise.toml
@@ -5,13 +5,19 @@ env_shell_expand = true
 output = "keep-order"
 
 [tasks.lint]
-depends = ['lint:*']
+depends = ['lint:*', 'fmt:justfile --check']
 
 [tasks."lint:expl3"]
 description = 'Lint expl3 code'
 alias = 'explcheck'
 env.EXPLCHECK_CONFIG = '{{ get_env(name="EXPLCHECK_CONFIG", default="config/explcheck.toml") }}'
 file = 'scripts/lint-expl3.sh'
+interactive = true
+
+[tasks."fmt:justfile"]
+description = 'Format justfiles'
+alias = 'justfile'
+run = 'just --fmt'
 interactive = true
 
 [tasks."lint:python"]
@@ -32,7 +38,7 @@ run = 'typos --config=config/typos.toml'
 [tasks."lint:pre-commit"]
 description = "Run pre-commit checks on all files"
 alias = 'pre-commit'
-env.SKIP = '{{ get_env(name="SKIP", default="typos,explcheck,ruff") }}'
+env.SKIP = '{{ get_env(name="SKIP", default="typos,justfile,explcheck,ruff") }}'
 run = [
   'echo "Skipped checks: {{ env.SKIP }}"',
   'pre-commit run --all-files --color=always'


### PR DESCRIPTION
`just --fmt [--check]` is more usable and stablized in just v1.50.0.
https://github.com/casey/just/releases/tag/1.50.0